### PR TITLE
refactor: ErrorResponse를 record로 리팩토링하고 예외 개선

### DIFF
--- a/src/main/java/com/example/prepost/global/exception/model/ErrorResponse.java
+++ b/src/main/java/com/example/prepost/global/exception/model/ErrorResponse.java
@@ -1,12 +1,14 @@
 package com.example.prepost.global.exception.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
 import org.springframework.http.HttpStatus;
 
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Builder
 public record ErrorResponse(
         int status,
         String code,
@@ -19,36 +21,36 @@ public record ErrorResponse(
     public record FieldValidationError(String field, String message) {}
 
     public static ErrorResponse of(ErrorCode errorCode, String message, Exception e) {
-        return new ErrorResponse(
-                errorCode.getStatus().value(),
-                errorCode.name(),
-                message,
-                LocalDateTime.now(),
-                e.getClass().getSimpleName(),
-                List.of()
-        );
+        return ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.name())
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .exception(e.getClass().getSimpleName())
+                .fieldErrors(List.of())
+                .build();
     }
 
     public static ErrorResponse of(ErrorCode errorCode, String message, Exception e, List<FieldValidationError> errors){
-        return new ErrorResponse(
-                errorCode.getStatus().value(),
-                errorCode.name(),
-                message,
-                LocalDateTime.now(),
-                e.getClass().getSimpleName(),
-                errors
-        );
+        return ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.name())
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .exception(e.getClass().getSimpleName())
+                .fieldErrors(errors)
+                .build();
     }
 
     public static ErrorResponse of(HttpStatus status, String message, Exception e){
-        return new ErrorResponse(
-                status.value(),
-                status.name(),
-                message,
-                LocalDateTime.now(),
-                e.getClass().getSimpleName(),
-                List.of()
-        );
+        return ErrorResponse.builder()
+                .status(status.value())
+                .code(status.name())
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .exception(e.getClass().getSimpleName())
+                .fieldErrors(List.of())
+                .build();
     }
 
 }

--- a/src/main/java/com/example/prepost/global/exception/model/ErrorResponse.java
+++ b/src/main/java/com/example/prepost/global/exception/model/ErrorResponse.java
@@ -1,28 +1,54 @@
 package com.example.prepost.global.exception.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.springframework.http.HttpStatus;
 
+
+import java.time.LocalDateTime;
 import java.util.List;
 
-@Getter
-@Builder
-@AllArgsConstructor
-public class ErrorResponse {
-    private int status;
-    private String code;
-    private String message;
+public record ErrorResponse(
+        int status,
+        String code,
+        String message,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime timestamp,
+        String exception,
+        List<FieldValidationError> fieldErrors
+) {
+    public record FieldValidationError(String field, String message) {}
 
-    //유효성 검사 에러
-    @Builder.Default //null값 방지
-    private List<FieldValidationError> fieldErrors = List.of(); //필드 초기화
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    public static class FieldValidationError{
-        private String field;
-        private String message;
+    public static ErrorResponse of(ErrorCode errorCode, String message, Exception e) {
+        return new ErrorResponse(
+                errorCode.getStatus().value(),
+                errorCode.name(),
+                message,
+                LocalDateTime.now(),
+                e.getClass().getSimpleName(),
+                List.of()
+        );
     }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message, Exception e, List<FieldValidationError> errors){
+        return new ErrorResponse(
+                errorCode.getStatus().value(),
+                errorCode.name(),
+                message,
+                LocalDateTime.now(),
+                e.getClass().getSimpleName(),
+                errors
+        );
+    }
+
+    public static ErrorResponse of(HttpStatus status, String message, Exception e){
+        return new ErrorResponse(
+                status.value(),
+                status.name(),
+                message,
+                LocalDateTime.now(),
+                e.getClass().getSimpleName(),
+                List.of()
+        );
+    }
+
 }


### PR DESCRIPTION
## 작업 내용
- ErrorRespones를 record로 리펙토링 하였습니다.
- ErrorResponse에 따른 GlobalExceptionHandler를 리펙토링 하였습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved error responses to be immutable and more detailed, including timestamps and exception information.
	- Enhanced consistency and clarity in error messages shown to users.
	- Streamlined error handling for a more reliable and predictable experience when errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->